### PR TITLE
Initialize random number generator at module load

### DIFF
--- a/lua/notes/utils.lua
+++ b/lua/notes/utils.lua
@@ -1,5 +1,8 @@
 -- Utility functions for notes.nvim plugin
 
+-- Seed the random number generator once at module load
+math.randomseed(os.time())
+
 local M = {}
 
 -- Helper function to ensure directory exists


### PR DESCRIPTION
Add math.randomseed call using os.time() at the top of the utils module. This ensures the random number generator is properly seeded when the module loads.